### PR TITLE
Add support for BitBucket and Jira

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,13 +6,14 @@ annotations to help readers gain more context:
 - ~yankee/yank-as-gfm-code-block~
 - ~yankee/yank-as-gfm-code-block-folded~
 - ~yankee/yank-as-org-code-block~
+- ~yankee/yank-as-jira-code-block~
 
 These are especially useful when composing issues and pull/merge requests on
 GitHub / GitLab / Bitbucket, but have broader utility as well.
 
 Each function yanks the selected code block and formats it as described by the
-function name: As GitHub-flavored Markdown, Foldable GFM, or an Org mode source
-block.
+function name: As GitHub-flavored Markdown, Foldable GFM, an Org mode source
+block, or Jira source block.
 
 If the file is in a project, its path relative to the project root will be used
 to annotate the code block with a comment including the selected line numbers.
@@ -40,13 +41,13 @@ Currently only supports Git."
     nil))
 ```
 <sup>
-  <a href="https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163">
+  <a href="https://github.com/jmromer/yankee/blob/ea278931/yankee.el#L158-L163">
     yankee.el#L158-L163 (ea278931)
   </a>
 </sup>
 #+END_SRC
 
-which produces this [[https://github.com/jkrmr/yankee/pull/1#user-content-gfm][output]]:
+which produces this [[https://github.com/jmromer/yankee/pull/1#user-content-gfm][output]]:
 
 #+CAPTION: yank-as-gfm-code-block
 #+NAME: fig: gfm
@@ -71,14 +72,14 @@ Currently only supports Git."
     nil))
 ```
 <sup>
-  <a href=https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163">
+  <a href=https://github.com/jmromer/yankee/blob/ea278931/yankee.el#L158-L163">
     yankee.el#L158-L163 (ea278931)
   </a>
 </sup>
 </details>
 #+END_SRC
 
-which produces this [[https://github.com/jkrmr/yankee/pull/1#user-content-gfm-foldable][output]]:
+which produces this [[https://github.com/jmromer/yankee/pull/1#user-content-gfm-foldable][output]]:
 
 #+CAPTION: yank-as-gfm-code-block-foldable
 #+NAME: fig: gfm-foldable
@@ -99,7 +100,7 @@ Currently only supports Git."
       (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
     nil))
 #+ END_SRC
-[[https://github.com/jkrmr/yankee/blob/517300b3/yankee.el#L158-L163] [yankee.el#L158-L163 (517300b3)]]
+[[https://github.com/jmromer/yankee/blob/517300b3/yankee.el#L158-L163] [yankee.el#L158-L163 (517300b3)]]
 #+END_SRC
 
 which produces this output:
@@ -114,7 +115,30 @@ Currently only supports Git."
       (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
     nil))
 #+END_SRC
-[[https://github.com/jkrmr/yankee/blob/517300b3/yankee.el#L158-L163][yankee.el#L158-L163 (517300b3)]]
+[[https://github.com/jmromer/yankee/blob/517300b3/yankee.el#L158-L163][yankee.el#L158-L163 (517300b3)]]
+
+** Jira
+
+#+BEGIN_SRC
+{code:python}
+# testproj/articles/models.py L4-L9 (ee46f59fb1)
+
+class Article(models.Model):
+    title = models.CharField(help_text="title model help_text", max_length=255, blank=False, unique=True)
+    body = models.TextField(help_text="article model help_text", max_length=5000, blank=False)
+    slug = models.SlugField(help_text="slug model help_text", unique=True, blank=True)
+    date_created = models.DateTimeField(auto_now_add=True)
+    date_modified = models.DateTimeField(auto_now=True)
+{code}
+
+[testproj/articles/models.py#L4-L9 (ee46f59fb1)|https://github.com/axnsan12/drf-yasg/blob/ee46f59fb1/testproj/articles/models.py#L4-L9]
+#+END_SRC
+
+which renders as follows:
+
+#+CAPTION: yank-as-jira-code-block
+#+NAME: fig: jira
+[[https://user-images.githubusercontent.com/4433943/39444725-b02dadb2-4c86-11e8-9a04-b03e6fd4503e.png][https://user-images.githubusercontent.com/4433943/39444725-b02dadb2-4c86-11e8-9a04-b03e6fd4503e.png]]
 
 ** Demo
 
@@ -135,7 +159,7 @@ Currently only supports Git."
   (load "yankee.el/yankee.el")
   (require 'yankee)
 #+END_SRC
-[[https://github.com/jkrmr/dotfiles/blob/8b3c0dcd/home/spacemacs.d/init.el#L319-L320][home/spacemacs.d/init.el#L319-L320 (8b3c0dcd)]]
+[[https://github.com/jmromer/dotfiles/blob/8b3c0dcd/home/spacemacs.d/init.el#L319-L320][home/spacemacs.d/init.el#L319-L320 (8b3c0dcd)]]
 
 *** Suggested keybindings for evil-mode
 
@@ -149,4 +173,4 @@ Currently only supports Git."
   (define-key evil-visual-state-map (kbd "gyf") #'yankee/yank-as-gfm-code-block-folded)
   (define-key evil-visual-state-map (kbd "gyo") #'yankee/yank-as-org-code-block)
 #+END_SRC
-[[https://github.com/jkrmr/dotfiles/blob/8b3c0dcd/home/spacemacs.d/init.el#L321-L324][home/spacemacs.d/init.el#L321-L324 (8b3c0dcd)]]
+[[https://github.com/jmromer/dotfiles/blob/8b3c0dcd/home/spacemacs.d/init.el#L321-L324][home/spacemacs.d/init.el#L321-L324 (8b3c0dcd)]]

--- a/README.org
+++ b/README.org
@@ -172,5 +172,6 @@ which renders as follows:
   (define-key evil-visual-state-map (kbd "gym") #'yankee/yank-as-gfm-code-block)
   (define-key evil-visual-state-map (kbd "gyf") #'yankee/yank-as-gfm-code-block-folded)
   (define-key evil-visual-state-map (kbd "gyo") #'yankee/yank-as-org-code-block)
+  (define-key evil-visual-state-map (kbd "gyj") #'yankee/yank-as-jira-code-block)
 #+END_SRC
 [[https://github.com/jmromer/dotfiles/blob/8b3c0dcd/home/spacemacs.d/init.el#L321-L324][home/spacemacs.d/init.el#L321-L324 (8b3c0dcd)]]

--- a/yankee.el
+++ b/yankee.el
@@ -139,7 +139,8 @@ Includes a filename comment annotation."
          (snippet-url (yankee--code-snippet-url (yankee--current-commit-remote)
                                                 commit-ref
                                                 file-name
-                                                selection-range))
+                                                selection-range
+                                                (line-number-at-pos start)))
          ;; Example: in tuareg-mode, 'tuareg-mode-hook' variable, as a symbol
          (mode-hook-atom (intern (format "%s-hook" mode-string)))
          ;; Store any mode hooks
@@ -195,7 +196,7 @@ Currently only supports Git."
   (insert "```" language "\n")
   (goto-char (point-max))
   (insert "\n\n" code "```\n")
-  (and url (insert (format "<sup>\n  <a href=\"%s\">\n    %s\n  </a>\n</sup>\n<p></p>\n" url path))))
+  (and url (insert (yankee--hyperlink-to-patch url path))))
 
 (defun yankee--gfm-code-fence-folded (language code path url)
   "Create a foldable GFM code block with LANGUAGE block containing CODE, PATH, and URL."
@@ -218,20 +219,48 @@ Currently only supports Git."
   (insert "\n\n" code "#+END_SRC\n")
   (and url (insert (format "[[%s][%s]]" url path))))
 
-(defun yankee--code-snippet-url (commit-remote commit-ref file-name selection-range)
-  "Generate the snippet url from COMMIT-REMOTE, COMMIT-REF, FILE-NAME, and the SELECTION-RANGE."
-  (and commit-remote
-       commit-ref
-       file-name
-       selection-range
-       (format "%s/blob/%s/%s#%s"
-               commit-remote
-               commit-ref
-               file-name
-               selection-range)))
+(defun yankee--code-snippet-url (commit-remote commit-ref file-name selection-range start-line)
+  "Generate the snippet url in the appropriate format depending on the service.
+Supports GitHub and BitBucket.
+
+Examples:
+COMMIT-REMOTE: https://github.com/orgname/reponame/file.py
+COMMIT-REF: 105561ec24
+FILE-NAME: file.py
+SELECTION-RANGE: L4-L8
+START-LINE: 4"
+  (if commit-remote
+      (cond
+       ;; GitHub URL format
+       ((string-match "github.com" commit-remote)
+        (and commit-ref file-name selection-range
+             (format "%s/blob/%s/%s#%s" commit-remote commit-ref file-name selection-range)))
+
+       ;; BitBucket URL format
+       ((string-match "bitbucket.org" commit-remote)
+        (and commit-ref file-name start-line
+             (format "%s/src/%s/%s#%s-%s" commit-remote commit-ref file-name file-name start-line))))))
+
+(defun yankee--hyperlink-to-patch (href-url text-path)
+  "Generate the hyperlink to the yanked patch in the appropriate format.
+Supports GitHub and BitBucket. HREF-URL becomes the href attribute,
+TEXT-PATH the anchor tag text."
+  (cond
+   ;;GitHub: Use HTML, display smaller
+   ((string-match "github.com" href-url)
+    (format "<sup>\n  <a href=\"%s\">\n    %s\n  </a>\n</sup>\n<p></p>\n" href-url text-path))
+
+   ;; BitBucket: Use Markdown
+   ((string-match "bitbucket.org" href-url)
+    (format "\n\n[%s](%s)" text-path href-url))))
+
 
 (defun yankee--code-snippet-path (commit-ref file-name selection-range)
-  "Generate the snippet path from COMMIT-REF, FILE-NAME, and the SELECTION-RANGE."
+  "Generate the snippet path. Displayed as the patch's hyperlink text.
+Examples:
+COMMIT-REF: 105561ec24
+FILE-NAME: appointments.py
+SELECTION-RANGE: L4-L5"
   (if commit-ref
       (format "%s#%s (%s)" file-name selection-range commit-ref)
     (format "%s#%s" file-name selection-range)))

--- a/yankee.el
+++ b/yankee.el
@@ -159,6 +159,8 @@ Includes a filename comment annotation."
              (yankee--gfm-code-fence language-mode selected-lines snippet-path snippet-url))
             ((equal format 'gfm-folded)
              (yankee--gfm-code-fence-folded language-mode selected-lines snippet-path snippet-url))
+            ((equal format 'jira)
+             (yankee--jira-code-fence language-mode selected-lines snippet-path snippet-url))
             ((equal format 'org)
              (yankee--org-code-fence language-mode selected-lines snippet-path snippet-url)))
       (clipboard-kill-ring-save (point-min) (point-max)))
@@ -218,6 +220,14 @@ Currently only supports Git."
   (goto-char (point-max))
   (insert "\n\n" code "#+END_SRC\n")
   (and url (insert (format "[[%s][%s]]" url path))))
+
+(defun yankee--jira-code-fence (language code path url)
+  "Create a Jira code block with LANGUAGE annotation containing CODE, PATH, and URL."
+  (goto-char (point-min))
+  (insert "{code:" language "}" "\n")
+  (goto-char (point-max))
+  (insert "\n\n" code "\{code\}\n\n")
+  (and url (insert (format "[%s|%s]" path url))))
 
 (defun yankee--code-snippet-url (commit-remote commit-ref file-name selection-range start-line)
   "Generate the snippet url in the appropriate format depending on the service.
@@ -281,6 +291,12 @@ Includes a filename comment annotation."
 Includes a filename comment annotation."
   (interactive "r")
   (yankee--yank-as-code-block 'org start end))
+
+(defun yankee/yank-as-jira-code-block (start end)
+  "In a Jira code fence, yank the selection bounded by START and END.
+Includes a filename comment annotation."
+  (interactive "r")
+  (yankee--yank-as-code-block 'jira start end))
 
 (provide 'yankee)
 ;;; yankee.el ends here

--- a/yankee.el
+++ b/yankee.el
@@ -235,7 +235,6 @@ START-LINE: 4"
        ((string-match "github.com" commit-remote)
         (and commit-ref file-name selection-range
              (format "%s/blob/%s/%s#%s" commit-remote commit-ref file-name selection-range)))
-
        ;; BitBucket URL format
        ((string-match "bitbucket.org" commit-remote)
         (and commit-ref file-name start-line
@@ -246,10 +245,9 @@ START-LINE: 4"
 Supports GitHub and BitBucket. HREF-URL becomes the href attribute,
 TEXT-PATH the anchor tag text."
   (cond
-   ;;GitHub: Use HTML, display smaller
+   ;; GitHub: Use HTML, display smaller
    ((string-match "github.com" href-url)
     (format "<sup>\n  <a href=\"%s\">\n    %s\n  </a>\n</sup>\n<p></p>\n" href-url text-path))
-
    ;; BitBucket: Use Markdown
    ((string-match "bitbucket.org" href-url)
     (format "\n\n[%s](%s)" text-path href-url))))


### PR DESCRIPTION
Adds the ability to yank code snippets in a format suitable for display on BitBucket and Jira.

Rendered Jira output:

![jira](https://user-images.githubusercontent.com/4433943/39444725-b02dadb2-4c86-11e8-9a04-b03e6fd4503e.png)
