### PR TITLE
Provide path as starting summary

### DIFF
--- a/yankee.el
+++ b/yankee.el
@@ -79,7 +79,7 @@ the given START-LINE and END-LINE (e.g., 'L5-L10', 'L5-10', or 'lines-5:10')."
   (cond ((equal format 'path)
          (if (equal start-line end-line)
              (format "L%s" (number-to-string start-line))
-           (format "L%s-L%s" (number-to-string start-line) (number-to-string end-line))))
+           (format "L%s-%s" (number-to-string start-line) (number-to-string end-line))))
         ((equal format 'github)
          (format "L%s-L%s" (number-to-string start-line) (number-to-string end-line)))
         ((equal format 'gitlab)

--- a/yankee.el
+++ b/yankee.el
@@ -344,8 +344,8 @@ COMMIT-REF: 105561ec24
 FILE-NAME: appointments.py
 SELECTION-RANGE: L4-L8."
   (if commit-ref
-      (format "%s#%s (%s)" file-name selection-range commit-ref)
-    (format "%s#%s" file-name selection-range)))
+      (format "%s %s (%s)" file-name selection-range commit-ref)
+    (format "%s %s" file-name selection-range)))
 
 (defun yankee/yank-as-gfm-code-block (start end)
   "In a GFM code fence, yank the selection bounded by START and END.

--- a/yankee.el
+++ b/yankee.el
@@ -262,7 +262,7 @@ Currently only supports Git."
   (goto-char (point-min))
   (insert "<details>\n")
   (insert "<summary>" )
-  (insert (read-string "Summary: "))
+  (insert (read-string "Summary: " path))
   (insert "</summary>\n\n")
   (insert "```" language "\n")
   (goto-char (point-max))


### PR DESCRIPTION
1. For folded GFM blocks, provide the comment string as the starting summary text.
2. Clean up the comment string (and anchor tag text) by removing the hash mark and second "L" prefix

### Demo
<img width="679" alt="screen shot 2018-05-20 at 10 28 40 pm" src="https://user-images.githubusercontent.com/4433943/40287955-ea5fe1e6-5c7e-11e8-9255-0acc6a4d2842.png">

### Results
<details>
<summary>yankee.el L260-271 (1daadcd50f)</summary>

```emacs-lisp
;; yankee.el L260-271 (1daadcd50f)

(defun yankee--gfm-code-fence-folded (language code path url)
  "Create a foldable GFM code block with LANGUAGE block containing CODE, PATH, and URL."
  (goto-char (point-min))
  (insert "<details>\n")
  (insert "<summary>" )
  (insert (read-string "Summary: " path))
  (insert "</summary>\n\n")
  (insert "```" language "\n")
  (goto-char (point-max))
  (insert "\n\n" code "```\n")
  (and url (insert (format "<sup>\n  <a href=\"%s\">\n    %s\n  </a>\n</sup>\n<p></p>\n" url path)))
  (insert "</details>"))
```
<sup>
  <a href="https://github.com/jmromer/yankee.el/blob/1daadcd50f/yankee.el#L260-L271">
    yankee.el L260-271 (1daadcd50f)
  </a>
</sup>
<p></p>
</details>

